### PR TITLE
Resolve conflicting job identifier in scheduler

### DIFF
--- a/football-prediction-app/backend/SCHEDULER_DEPLOYMENT.md
+++ b/football-prediction-app/backend/SCHEDULER_DEPLOYMENT.md
@@ -1,0 +1,114 @@
+# Scheduler Deployment Guide for Render
+
+## Problem
+When deploying a Flask app with APScheduler on Render using Gunicorn with multiple workers, you may encounter the error:
+```
+apscheduler.jobstores.base.ConflictingIdError: 'Job identifier (initial_fetch) conflicts with an existing job'
+```
+
+This happens because each Gunicorn worker process creates its own instance of the Flask app and scheduler, leading to conflicts.
+
+## Solution
+
+### Option 1: Use Environment Variables (Recommended)
+
+1. **Set up environment variables on Render:**
+   - `ENABLE_SCHEDULER=true` - Enable the scheduler functionality
+   - `IS_SCHEDULER_INSTANCE=true` - Set this ONLY on one service instance
+
+2. **For a single web service:**
+   - Set both environment variables to `true`
+   - The scheduler will run in the same process as your web server
+
+3. **For multiple services or scaling:**
+   - Create a separate "Background Worker" service on Render
+   - Set `ENABLE_SCHEDULER=true` and `IS_SCHEDULER_INSTANCE=true` only on the worker
+   - Set `ENABLE_SCHEDULER=false` on all web service instances
+
+### Option 2: Use Gunicorn Preload (Alternative)
+
+1. **Update your Gunicorn command:**
+   ```bash
+   gunicorn --preload -w 4 wsgi:app
+   ```
+
+2. **Modify scheduler.py to use file-based locking:**
+   ```python
+   import fcntl
+   
+   # In the start() method
+   lock_file = '/tmp/scheduler.lock'
+   with open(lock_file, 'w') as f:
+       try:
+           fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+           # Start scheduler here
+       except IOError:
+           logger.info("Scheduler already running in another process")
+   ```
+
+### Option 3: Separate Scheduler Service (Best for Production)
+
+1. **Create a separate scheduler script (`run_scheduler.py`):**
+   ```python
+   from app import create_app
+   from scheduler import data_scheduler
+   
+   app = create_app()
+   data_scheduler.init_app(app)
+   data_scheduler.start()
+   
+   # Keep the script running
+   import time
+   while True:
+       time.sleep(60)
+   ```
+
+2. **Deploy as a Background Worker on Render:**
+   - Create a new "Background Worker" service
+   - Set the start command to: `python run_scheduler.py`
+   - Disable scheduler on web services: `ENABLE_SCHEDULER=false`
+
+## Current Implementation
+
+The current implementation uses Option 1 with environment variables:
+
+- The scheduler checks for `IS_SCHEDULER_INSTANCE=true` before starting
+- Jobs are added with `replace_existing=True` to handle restarts gracefully
+- Individual job additions are wrapped in try/except to handle conflicts
+- The scheduler includes proper cleanup on shutdown
+
+## Deployment Steps on Render
+
+1. **In your Render dashboard:**
+   - Go to your web service settings
+   - Add environment variables:
+     - `ENABLE_SCHEDULER=true`
+     - `IS_SCHEDULER_INSTANCE=true`
+   
+2. **If you have multiple instances or auto-scaling:**
+   - Create a new Background Worker service
+   - Use the same repo and branch
+   - Set start command: `python run_scheduler.py` (if using Option 3)
+   - Add environment variables to the worker service only
+
+3. **Monitor logs** to ensure scheduler starts correctly:
+   ```
+   INFO:scheduler:Scheduler started with all jobs configured
+   ```
+
+## Troubleshooting
+
+1. **ConflictingIdError persists:**
+   - Ensure only one instance has `IS_SCHEDULER_INSTANCE=true`
+   - Check that jobs use `replace_existing=True`
+   - Verify no duplicate scheduler initialization
+
+2. **Scheduler not running:**
+   - Check environment variables are set correctly
+   - Verify logs show scheduler initialization
+   - Ensure database connection is available
+
+3. **Jobs not executing:**
+   - Check timezone settings
+   - Verify API keys are configured
+   - Monitor scheduler logs for errors

--- a/football-prediction-app/backend/app.py
+++ b/football-prediction-app/backend/app.py
@@ -86,14 +86,17 @@ def create_app(config_name=None):
             except Exception as e:
                 print(f"Warning: Could not create database tables: {e}")
     
-    # Initialize scheduler if enabled
-    if app.config.get('ENABLE_SCHEDULER', False):
+    # Initialize scheduler if enabled and this is the scheduler instance
+    # For Render: Set ENABLE_SCHEDULER=true and IS_SCHEDULER_INSTANCE=true on only one service
+    if app.config.get('ENABLE_SCHEDULER', False) and os.environ.get('IS_SCHEDULER_INSTANCE', 'false').lower() == 'true':
         from scheduler import data_scheduler
         data_scheduler.init_app(app)
         data_scheduler.start()
         
         # Register cleanup on app shutdown
         atexit.register(lambda: data_scheduler.shutdown())
+    elif app.config.get('ENABLE_SCHEDULER', False):
+        print("Scheduler is enabled but this is not the scheduler instance (IS_SCHEDULER_INSTANCE != true)")
     
     @app.route('/')
     def index():

--- a/football-prediction-app/backend/run_scheduler.py
+++ b/football-prediction-app/backend/run_scheduler.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""
+Standalone scheduler runner for deployment as a separate service
+"""
+import os
+import sys
+import time
+import logging
+from app import create_app
+from scheduler import data_scheduler
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def main():
+    """Run the scheduler as a standalone process"""
+    logger.info("Starting standalone scheduler process...")
+    
+    # Force scheduler instance flag
+    os.environ['IS_SCHEDULER_INSTANCE'] = 'true'
+    os.environ['ENABLE_SCHEDULER'] = 'true'
+    
+    # Create Flask app with production config
+    app = create_app('production')
+    
+    # Initialize and start scheduler
+    with app.app_context():
+        data_scheduler.init_app(app)
+        data_scheduler.start()
+        
+        logger.info("Scheduler started successfully. Running indefinitely...")
+        
+        # Keep the process running
+        try:
+            while True:
+                time.sleep(60)  # Sleep for 1 minute
+                # You could add health checks or status logging here
+                if not data_scheduler.scheduler.running:
+                    logger.error("Scheduler stopped unexpectedly! Attempting restart...")
+                    data_scheduler.start()
+        except KeyboardInterrupt:
+            logger.info("Received interrupt signal, shutting down...")
+            data_scheduler.shutdown()
+            sys.exit(0)
+        except Exception as e:
+            logger.error(f"Scheduler process error: {e}")
+            data_scheduler.shutdown()
+            sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement robust APScheduler management to prevent job ID conflicts in multi-process environments like Gunicorn on Render.

When deploying with Gunicorn, multiple worker processes can each attempt to initialize and start APScheduler, leading to `ConflictingIdError` due to duplicate job IDs. This PR introduces an environment variable (`IS_SCHEDULER_INSTANCE`) to designate a single process as the scheduler runner, and provides a dedicated script for a separate scheduler worker, ensuring only one active scheduler instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c43ce03-5829-4970-82f6-353a8bd63f79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c43ce03-5829-4970-82f6-353a8bd63f79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

