### PR TITLE
Fix typescript error in build

### DIFF
--- a/football-prediction-app/frontend/src/pages/TeamDetails.tsx
+++ b/football-prediction-app/frontend/src/pages/TeamDetails.tsx
@@ -109,7 +109,21 @@ const TeamDetails: React.FC = () => {
   }
 
   const { team } = teamData;
-  const statistics = statsData?.statistics || {};
+  const statistics = statsData?.statistics || {
+    position: undefined,
+    points: undefined,
+    season: '',
+    matches_played: 0,
+    wins: 0,
+    draws: 0,
+    losses: 0,
+    goals_for: 0,
+    goals_against: 0,
+    form: '',
+    clean_sheets: 0,
+    home_record: { wins: 0, draws: 0, losses: 0 },
+    away_record: { wins: 0, draws: 0, losses: 0 }
+  };
 
   return (
     <Box>


### PR DESCRIPTION
Provide a complete default `TeamStatistics` object to resolve a TypeScript error when `statistics` data is undefined.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5e9656d-43e8-4a14-ac95-a74291027118">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5e9656d-43e8-4a14-ac95-a74291027118">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

