### PR TITLE
Fix duplicate health route and deployment errors

### DIFF
--- a/football-prediction-app/backend/app.py
+++ b/football-prediction-app/backend/app.py
@@ -198,34 +198,6 @@ def create_app(config_name=None):
             }
         }
     
-    @app.route('/health')
-    def health():
-        """Health check endpoint"""
-        db_status = 'unknown'
-        db_error = None
-        
-        try:
-            # Test database connection
-            from sqlalchemy import text
-            db.session.execute(text('SELECT 1'))
-            db.session.commit()
-            db_status = 'connected'
-        except Exception as e:
-            db_status = 'disconnected'
-            db_error = str(e)
-            
-        return {
-            'status': 'healthy',
-            'environment': config_name,
-            'database': {
-                'status': db_status,
-                'error': db_error,
-                'uri_configured': bool(app.config.get('SQLALCHEMY_DATABASE_URI')),
-                'is_postgresql': 'postgresql' in str(app.config.get('SQLALCHEMY_DATABASE_URI', ''))
-            },
-            'api_key_configured': bool(app.config.get('FOOTBALL_API_KEY'))
-        }
-    
     # Catch-all route for React app - must be last
     @app.route('/<path:path>')
     def serve_react_app(path):


### PR DESCRIPTION
Consolidate `/health` endpoint into `monitoring.py` to resolve duplicate route deployment error.

---
<a href="https://cursor.com/background-agent?bcId=bc-5550cd5f-8149-468d-82e0-86b2c20c8d9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5550cd5f-8149-468d-82e0-86b2c20c8d9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

